### PR TITLE
Fix Blueprints mobile SiteName color

### DIFF
--- a/src/components/atoms/SiteName/styles.module.scss
+++ b/src/components/atoms/SiteName/styles.module.scss
@@ -18,6 +18,12 @@
 
 	&.dark {
 		color: $black;
+		 a {
+			color: $black;
+			&:hover {
+				color: $primary;
+			}
+		}
 	}
 
 	@media screen and (max-width: $screenSmall) {


### PR DESCRIPTION
Override the defined SiteName anchor color through the `.dark` class for #153 