### PR TITLE
Set overflow to auto to prevent

### DIFF
--- a/src/components/organisms/Sidebar/styles.module.scss
+++ b/src/components/organisms/Sidebar/styles.module.scss
@@ -7,7 +7,7 @@
 	height: 100%;
 	max-height: 100vh;
 	position: sticky;
-	overflow: scroll;
+	overflow: auto;
 	top: 0;
 	transition: transform 0.5s ease-in-out, opacity 0.5s ease-out 0s;
 	list-style: none;


### PR DESCRIPTION
This prevents the display of unnecessary scrollbars on large screens but still makes able to scroll when the screen size is smaller.

Original:
![image](https://user-images.githubusercontent.com/1768446/48918668-70cc3d00-ee8e-11e8-8847-c4538d15735a.png)


Updated:
![image](https://user-images.githubusercontent.com/1768446/48918650-4f6b5100-ee8e-11e8-8757-f597d0db167d.png)
