### PR TITLE
fix #442

### DIFF
--- a/src/components/atoms/SiteName/index.js
+++ b/src/components/atoms/SiteName/index.js
@@ -12,8 +12,12 @@ const SiteName = ({ dark, section, underlineColor }) => {
 
 	return (
 		<div className={`${styles.siteName} ${dark && styles.dark}`}>
-			<Link to="/">Liferay.Design<span style={{background:`${underlineColor}`}} className={styles.underline}></span></Link>
+			<Link to="/">Liferay.Design</Link>
 			{section && <Link to={'/' + `${lowerCaseSection}`}> / {section}</Link>}
+			<span
+				style={{ background: `${underlineColor}` }}
+				className={styles.underline}
+			/>
 		</div>
 	)
 }

--- a/src/components/atoms/SiteName/index.js
+++ b/src/components/atoms/SiteName/index.js
@@ -2,8 +2,9 @@ import { Link } from 'components/atoms'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles.module.scss'
+import Blueprints from 'pages/blueprints';
 
-const SiteName = ({ dark, section }) => {
+const SiteName = ({ dark, section, underlineColor }) => {
 	var str = section
 	if (str !== undefined) {
 		var lowerCaseSection = str.toLowerCase()
@@ -11,7 +12,7 @@ const SiteName = ({ dark, section }) => {
 
 	return (
 		<div className={`${styles.siteName} ${dark && styles.dark}`}>
-			<Link to="/">Liferay.Design</Link>
+			<Link to="/">Liferay.Design<span style={{background:`${underlineColor}`}} className={styles.underline}></span></Link>
 			{section && <Link to={'/' + `${lowerCaseSection}`}> / {section}</Link>}
 		</div>
 	)
@@ -20,6 +21,7 @@ const SiteName = ({ dark, section }) => {
 SiteName.propTypes = {
 	dark: PropTypes.bool,
 	section: PropTypes.string,
+	underlineColor: PropTypes.string,
 }
 
 export default SiteName

--- a/src/components/atoms/SiteName/styles.module.scss
+++ b/src/components/atoms/SiteName/styles.module.scss
@@ -4,11 +4,12 @@
 	font-size: $fontSizeMedium;
 	padding-bottom: 0;
 	line-height: 1.6;
+	position: relative;
 	a {
 		color: $white;
 	}
-	&:after {
-		content: '';
+	.underline {
+		position: absolute;
 		width: $spacingBase;
 		height: 3px;
 		background: $primary;
@@ -18,7 +19,7 @@
 
 	&.dark {
 		color: $black;
-		 a {
+		a {
 			color: $black;
 			&:hover {
 				color: $primary;

--- a/src/components/organisms/Banner/index.js
+++ b/src/components/organisms/Banner/index.js
@@ -6,9 +6,9 @@ import React from 'react'
 import { Button } from 'reakit'
 import styles from './styles.module.scss'
 
-const Banner = ({ headline, subtitle, cta, ctaLink, section, background }) => (
+const Banner = ({ underlineColor, headline, subtitle, cta, ctaLink, section, background }) => (
 	<Flex className={styles.container} style={{ background: `${background}` }}>
-		<Navbar white section={section} />
+		<Navbar underlineColor={underlineColor} white section={section} />
 		<Flex direction="column" align="center" className={styles.content}>
 			<Heading color="white" level={1}>
 				{headline}
@@ -27,6 +27,7 @@ const Banner = ({ headline, subtitle, cta, ctaLink, section, background }) => (
 
 Banner.propTypes = {
 	headline: PropTypes.string,
+	underlineColor: PropTypes.string,
 	subtitle: PropTypes.string,
 	cta: PropTypes.string,
 	ctaLink: PropTypes.string,

--- a/src/components/organisms/Navbar/index.js
+++ b/src/components/organisms/Navbar/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles.module.scss'
 
-const Navbar = ({ white, section }) => {
+const Navbar = ({ white, section, underlineColor }) => {
 	// TODO: Add custom nav items for events page
 	// const navItems = ['agenda', 'blueprints', 'dashboard', 'team', 'venue']
 
@@ -17,7 +17,7 @@ const Navbar = ({ white, section }) => {
 	return (
 		<Container>
 			<nav className={white ? styles.white : styles.default}>
-				<SiteName section={section} />
+				<SiteName underlineColor={underlineColor} section={section} />
 
 				<NavItems />
 			</nav>
@@ -28,6 +28,7 @@ const Navbar = ({ white, section }) => {
 Navbar.propTypes = {
 	href: PropTypes.string,
 	selected: PropTypes.string,
+	underlineColor: PropTypes.string,
 }
 
 export default Navbar

--- a/src/pages/blueprints/index.js
+++ b/src/pages/blueprints/index.js
@@ -19,6 +19,7 @@ const Blueprints = () => (
 			ctaLink="/blueprints/principles"
 			section="Blueprints"
 			background="linear-gradient(20deg, rgba(11, 99, 206, 0.4), rgba(11, 99, 206, 0.6)), url(/images/home/blueprints-bg.svg) center -6rem / cover fixed, #0b63ff"
+			underlineColor="#134194"
 		/>
 		<div className={styles.background}>
 			<div className={styles.container}>

--- a/src/pages/lexicon-1/index.js
+++ b/src/pages/lexicon-1/index.js
@@ -15,6 +15,7 @@ const Lexicon = () => (
 			ctaLink="/lexicon-1/get-started"
 			section="Lexicon 1"
 			background="linear-gradient(20deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 1.0)), url(/images/lexicon/home/pattern-bg-black.svg) center -6rem / cover fixed, #000"
+			underlineColor="#c96678"
 		/>
 		<div className={styles.background}>
 			<div className={styles.container}>

--- a/src/pages/lexicon/index.js
+++ b/src/pages/lexicon/index.js
@@ -15,6 +15,7 @@ const Lexicon = () => (
 			ctaLink="/lexicon/get-started"
 			section="Lexicon"
 			background="url(/images/lexicon/home/patternbg.svg) center fixed, #0B5FFF"
+			underlineColor="#5fe5c1"
 		/>
 		<div className={styles.background}>
 			<div className={styles.container}>


### PR DESCRIPTION
Added a prop `underlineColor` to the Sitename components (passes through Navbar and Banner components) — this allows you to customize the color of the stylized underscore in the navbar.