### PR TITLE
:bug: Uninterpreted markdown

### DIFF
--- a/src/markdown/lexicon/core-components/table/table.mdx
+++ b/src/markdown/lexicon/core-components/table/table.mdx
@@ -73,7 +73,7 @@ When the row is selected, the actions do not appear on hover state.
 
 ![table row in selected state](/images/lexicon/TableViewSelected.jpg)
 
-### Row attributes
+### Row attributes
 
 ![table row in hover state](/images/lexicon/TableViewDefaultParts.jpg)
 


### PR DESCRIPTION
A tab instead of the space was preventing the heading to be interpreted