### PR TITLE
Fix styling bugs on Lexicon site

### DIFF
--- a/src/components/templates/Lexicon/index.js
+++ b/src/components/templates/Lexicon/index.js
@@ -1,5 +1,5 @@
 import { ContainerMarkdown, Flex, Icon, SiteName, Text, Link } from 'components/atoms'
-import { MDXRenderer } from "gatsby-plugin-mdx"
+import { MDXRenderer } from 'gatsby-plugin-mdx'
 import { AuthContainer, GlobalMdx } from 'components/molecules'
 import { Footer, Sidebar } from 'components/organisms'
 import { graphql } from 'gatsby'
@@ -81,7 +81,7 @@ export default class Lexicon extends Component {
 						return (
 							<Grid
 								template={gridTemplate}
-								className={documentation.mainContentWrapper}
+								className={`${documentation.mainContentWrapper} ${lexicon.mainContentWrapper}`}
 							>
 								{matches && (
 									<Flex
@@ -117,34 +117,24 @@ export default class Lexicon extends Component {
 										</Flex>
 
 										{mdx.frontmatter.titleLabelLink ? (
-											<span>
-												<Link
-													className={lexicon.labelWarning}
-													to={mdx.frontmatter.titleLabelLink}
-												>
-													VIEW IN CLAY
-												</Link>
-											</span>
+											<Link
+												className={lexicon.labelWarning}
+												to={mdx.frontmatter.titleLabelLink}
+											>
+												View in Clay
+											</Link>
 										) : null}
 
 										{mdx.frontmatter.productName ? (
-											<span>
-												<Link
-													className={lexicon.labelInfo}
-												>
-													{mdx.frontmatter.productName}
-												</Link>
-											</span>
+											<Link className={lexicon.labelInfo}>
+												{mdx.frontmatter.productName}
+											</Link>
 										) : null}
 
 										{mdx.frontmatter.devStatus ? (
-											<span>
-												<Link
-													className={lexicon.labelDraft}
-												>
-													{mdx.frontmatter.devStatus}
-												</Link>
-											</span>
+											<Link className={lexicon.labelDraft}>
+												{mdx.frontmatter.devStatus}
+											</Link>
 										) : null}
 
 										{mdx.frontmatter.description ? (
@@ -225,7 +215,7 @@ export const pageQuery = graphql`
 				devStatus
 				productName
 			}
-				body
+			body
 		}
 	}
 `

--- a/src/markdown/blueprints/guidelines/legal-notice.md
+++ b/src/markdown/blueprints/guidelines/legal-notice.md
@@ -21,7 +21,7 @@ Indicated by the symbol ©, copyrights protect our exclusive rights of creations
 
 For more information on copyrights, see our [internal policy for marking our source code](https://grow.liferay.com/share/Liferay+Policy+for+Marking+Our+Own+Source+Code) or our [internal copyright FAQ](https://grow.liferay.com/share/Internal+Liferay+Copyright+%3CAMPERSAND%3E+Licensing+FAQ).
 
-## Status Information | November 2019
+## Status Information | February 2020
 
 ### We Have Registered The Following Trademarks In The United States And Can Use The &reg; Symbol
 
@@ -30,15 +30,16 @@ Special form drawings (word and logo combo):
 -   Liferay _(Registered May 21, 2019)_
 -   Liferay Digital Experience Platform _(Registered July 30, 2019)_
 -   Liferay Commerce _(Registered July 30, 2019)_
+-   Liferay Analytics Cloud _(Registered February 04, 2020)_
 
 Standard Character Marks (word trademarks):
 
 -   Liferay _(Registered March 31, 2015)_
--   Liferay DXP _(Registered October 31, 2017)_
--   WeDeploy _(Registered December 21, 2017)_
--   Liferay Analytics Cloud _(Registered August 06, 2019)_
 -   Liferay Digital Experience Platform _(Registered October 17, 2017)_
+-   Liferay DXP _(Registered October 31, 2017)_
 -   Liferay Commerce _(Registered October 15, 2019)_
+-   Liferay Analytics Cloud _(Registered August 06, 2019)_
+-   WeDeploy _(Registered December 21, 2017)_
 
 ### In The United States The Following Trademarks Are Still Work In Progress
 
@@ -51,9 +52,7 @@ Standard Character Marks (word trademarks):
 -   Mapo
 -   Testray
 
-Special form drawings (word and logo combo):
-
--   Liferay Analytics Cloud
+<!-- Special form drawings (word and logo combo): -->
 
 If you are interested in other territories [please let us know](mailto:paul.hanaoka@liferay.com).
 

--- a/src/theme/lexicon.module.scss
+++ b/src/theme/lexicon.module.scss
@@ -1,5 +1,24 @@
 @import '~theme/variables';
 
+@mixin label {
+	background-color: $white;
+	border-radius: 0.125rem;
+	border-style: solid;
+	border-width: 0.0625rem;
+	display: inline-flex;
+	font-size: 10px;
+	font-weight: 600;
+	margin: 0 0.5rem 0 0;
+	padding-left: 4px;
+	padding-right: 4px;
+	position: relative;
+	text-transform: uppercase;
+	top: -2.5rem;
+	@media (max-width: $grid-float-breakpoint - 1) {
+		margin-top: 1.5rem;
+	}
+}
+
 .theme {
 	font-family: $fontFamilySystem;
 
@@ -57,69 +76,21 @@
 		}
 
 		.labelWarning {
+			@include label;
 			border-color: $warning-l1;
 			color: $warning;
-			font-size: 10px;
-			font-weight: 600;
-			margin: 0 0.5rem 0 0;
-			padding-left: 4px;
-			padding-right: 4px;
-			background-color: $white;
-			border-radius: 0.125rem;
-			border-style: solid;
-			border-width: 0.0625rem;
-			display: inline-flex;
-
-			position: relative;
-			top: -2.5rem;
-
-			@media (max-width: $grid-float-breakpoint - 1) {
-				margin-top: 1.5rem;
-			}
 		}
 
 		.labelDraft {
+			@include label;
 			border-color: $main-l4;
 			color: $main-l3;
-			font-size: 10px;
-			font-weight: 600;
-			margin: 0 0.5rem 0 0;
-			padding-left: 4px;
-			padding-right: 4px;
-			background-color: $white;
-			border-radius: 0.125rem;
-			border-style: solid;
-			border-width: 0.0625rem;
-			display: inline-flex;
-
-			position: relative;
-			top: -2.5rem;
-
-			@media (max-width: $grid-float-breakpoint - 1) {
-				margin-top: 1.5rem;
-			}
 		}
 
 		.labelInfo {
+			@include label;
 			border-color: $info-l1;
 			color: $info;
-			font-size: 10px;
-			font-weight: 600;
-			margin: 0 0.5rem 0 0;
-			padding-left: 4px;
-			padding-right: 4px;
-			background-color: $white;
-			border-radius: 0.125rem;
-			border-style: solid;
-			border-width: 0.0625rem;
-			display: inline-flex;
-
-			position: relative;
-			top: -2.5rem;
-
-			@media (max-width: $grid-float-breakpoint - 1) {
-				margin-top: 1.5rem;
-			}
 		}
 
 		p {

--- a/src/theme/lexicon.module.scss
+++ b/src/theme/lexicon.module.scss
@@ -13,12 +13,16 @@
 	padding-right: 4px;
 	position: relative;
 	text-transform: uppercase;
+	white-space: nowrap;
+}
+
+@mixin documentLabel {
+	position: relative;
 	top: -2.5rem;
 	@media (max-width: $grid-float-breakpoint - 1) {
 		margin-top: 1.5rem;
 	}
 }
-
 .theme {
 	font-family: $fontFamilySystem;
 
@@ -77,18 +81,21 @@
 
 		.labelWarning {
 			@include label;
+			@include documentLabel;
 			border-color: $warning-l1;
 			color: $warning;
 		}
 
 		.labelDraft {
 			@include label;
+			@include documentLabel;
 			border-color: $main-l4;
 			color: $main-l3;
 		}
 
 		.labelInfo {
 			@include label;
+			@include documentLabel;
 			border-color: $info-l1;
 			color: $info;
 		}
@@ -220,65 +227,71 @@
 	}
 }
 
+@mixin doDont {
+	border-style: solid;
+	font-weight: 600;
+}
+
+:global(.labelTag) {
+	@include label;
+}
+
+:global(.labelCorrection) {
+	@include documentLabel;
+}
+
 :global(.designerInfo) {
 	color: $info;
 	font-size: 0.875rem;
 }
 
 :global(.do) {
-	border-style: solid;
-	border-width: 4px 0px 0px 0px;
+	@include doDont;
 	border-color: $success-l1;
 	color: $success;
-	font-weight: 600;
+	border-width: 4px 0px 0px 0px;
 }
 
 :global(.dont) {
-	border-style: solid;
-	border-width: 4px 0px 0px 0px;
+	@include doDont;
 	border-color: $error-l1;
 	color: $error;
-	font-weight: 600;
+	border-width: 4px 0px 0px 0px;
 }
 
 :global(.avoid) {
-	border-style: solid;
-	border-width: 4px 0px 0px 0px;
+	@include doDont;
 	border-color: $warning-l1;
 	color: $warning;
-	font-weight: 600;
+	border-width: 4px 0px 0px 0px;
 }
 
 :global(.do-text) {
+	@include doDont;
 	color: $success;
-	font-weight: 600;
-	border-style: solid;
 	border-width: 0px 0px 0px 4px;
 	border-color: $success-l1;
 	padding-left: 1rem;
 }
 
 :global(.dont-text) {
+	@include doDont;
 	color: $error;
-	font-weight: 600;
-	border-style: solid;
 	border-width: 0px 0px 0px 4px;
 	border-color: $error-l1;
 	padding-left: 1rem;
 }
 
 :global(.do-table) {
+	@include doDont;
 	color: $success;
-	font-weight: 600;
-	border-style: solid;
 	border-width: 0px 0px 4px 0px;
 	border-color: $success-l1;
 }
 
 :global(.dont-table) {
+	@include doDont;
 	color: $error;
-	font-weight: 600;
-	border-style: solid;
 	border-width: 0px 0px 4px 0px;
 	border-color: $error-l1;
 }
@@ -315,21 +328,6 @@
 	font-weight: 600;
 }
 
-:global(.labelTag) {
-	font-size: 10px;
-	font-weight: 600;
-	margin: 0 0.5rem 0 0;
-	padding-left: 4px;
-	padding-right: 4px;
-	background-color: $white;
-	border-radius: 0.125rem;
-	border-style: solid;
-	border-width: 0.0625rem;
-	display: inline-flex;
-	line-height: 1rem;
-	white-space: nowrap;
-}
-
 :global(.labelDraft) {
 	border-color: $main-l4;
 	color: $main-l3;
@@ -343,13 +341,4 @@
 :global(.labelWarning) {
 	border-color: $warning-l1;
 	color: $warning;
-}
-
-:global(.labelCorrection) {
-	position: relative;
-	top: -2.5rem;
-
-	@media (max-width: $grid-float-breakpoint - 1) {
-		margin-top: 1.5rem;
-	}
 }


### PR DESCRIPTION
- add the right class to Lexicon page wrapper
- use mixins to reduce css redundancy (cc @liferay-design/lexicon check out [805a85f](https://github.com/liferay-design/liferay.design/commit/805a85f0e22a06051fc584afb0baedd05651bdb5))
- update blueprints legal notice