### PR TITLE
Adds Slack channel and fixes Calendar link

### DIFF
--- a/src/markdown/handbook/advocate/index.mdx
+++ b/src/markdown/handbook/advocate/index.mdx
@@ -9,6 +9,8 @@ import { Image } from 'components/atoms'
 
 ## Creating, extending, and organizing content.
 
+Use the [#des-public-relations](https://join.slack.com/share/zt-e10g2l43-Eg5DaA~0kzMhmTjqKDftDA) channel to share ideas and discuss about advocating initiatives. 
+
 ## Why
 
 Sharing our work is important for increasing the influence of our department. Highlighting our work beyond finished products, to how and why we do things will help everyone. Sharing these things thoroughly and transparently has two primary benefits:
@@ -103,10 +105,7 @@ Managing all of this _could be_ someone’s full-time job. But our goal, by crea
 
 export const caption = (
 	<p>
-		This is our Editorial Trello Board. It also has{' '}
-		<a href="https://trello.com/b/CjHnF2Zs/editorial-calendar/calendar/2019/07">
-			a Calendar view
-		</a>
+		This is our Editorial Trello Board.
 		. If you aren’t in the Trello Team, <a href="https://trello.com/invite/liferaydesign/5094c905ce91e5adc6eeee02c513c70f">
 			join today
 		</a>!

--- a/src/markdown/handbook/advocate/index.mdx
+++ b/src/markdown/handbook/advocate/index.mdx
@@ -105,7 +105,10 @@ Managing all of this _could be_ someone’s full-time job. But our goal, by crea
 
 export const caption = (
 	<p>
-		This is our Editorial Trello Board.
+		This is our Editorial Trello Board. It also has
+		<a href="https://trello.com/b/CjHnF2Zs/editorial-calendar/calendar/">		
+			a Calendar view		
+		</a>
 		. If you aren’t in the Trello Team, <a href="https://trello.com/invite/liferaydesign/5094c905ce91e5adc6eeee02c513c70f">
 			join today
 		</a>!


### PR DESCRIPTION
1. Added the public relations Slack channel
2. Remove the Trello's Calendar view because its link doesn't work