### PR TITLE
Tiny corrections

### DIFF
--- a/src/markdown/lexicon/core-components/buttons/action-buttons.mdx
+++ b/src/markdown/lexicon/core-components/buttons/action-buttons.mdx
@@ -63,15 +63,16 @@ However, action-based color buttons can be used in modals for status messages to
 As with any other primary call-to-action button, do not place two action-based color buttons together as this can force the user to spend time making sense of the color-label association.
 
 ![modal for status message with action-based color button and a secondary button Don't](/images/lexicon/ModalsStatusMessagesDont.png)
-<p class="dont-table">Don't</p>
+<p class="dont">Don't</p>
 
 <br/>
 
 ![modal for status message with action-based color button and a secondary button Do](/images/lexicon/ModalsStatusMessagesDo.png)
-<p class="do-table">Do</p>
+<p class="do">Do</p>
 
 <br/>
 <br/>
+
 In a context where an action-based color button is next to a secondary button, you can choose to style the latter, using a secondary button as shown in the previous image or a secondary action-based color button as shown in the following image.
 
 ![Component with action-based color button and a secondary action button](/images/lexicon/TwoActionButtons.png)

--- a/src/markdown/lexicon/examples/asset-metrics-dashboard.mdx
+++ b/src/markdown/lexicon/examples/asset-metrics-dashboard.mdx
@@ -34,21 +34,18 @@ Focusing on the asset detail page, Analytics Cloud help you analyzing the inform
 	rounded
 	dropShadow
 	align="left"
+	margin="36px"
 	size="large"
 	alt="Asset metrics dasboard in Liferay Analytics Cloud"
 	caption="Metrics on a Contact Form for a Support Team"
 	src="/images/lexicon/examples/assetMetricsDashboard.jpg"
 />
 
+<br/>
+<br/>
 
 Liferay Analytics Cloud provides the ability to analyze user profile data and interactions with dynamic pages and assets, displaying meaningful insights in the form of chart dashboards. These dashboards gather raw metrics data and deliver an easily readable measurable view for applications such as forms, blogs, documents, media and other pieces of web content.
 
 Focusing on the asset detail page, Analytics Cloud help you analyzing the information related to each asset with metrics related to visor behaviour, metrics focused on your defined segments, geographical stats and devicce related metrics. All this information help users knowing what is the impact of their assets from different perspectives a take decisions towards better conversion rates.
 
-<br />
 
-Liferay Analytics Cloud provides the ability to analyze user profile data and interactions with dynamic pages and assets, displaying meaningful insights in the form of chart dashboards. These dashboards gather raw metrics data and deliver an easily readable measurable view for applications such as forms, blogs, documents, media and other pieces of web content.
-
-Focusing on the asset detail page, Analytics Cloud help you analyzing the information related to each asset with metrics related to visor behaviour, metrics focused on your defined segments, geographical stats and devicce related metrics. All this information help users knowing what is the impact of their assets from different perspectives a take decisions towards better conversion rates.
-
-<br />

--- a/src/theme/lexicon.module.scss
+++ b/src/theme/lexicon.module.scss
@@ -112,14 +112,18 @@
 			color: $main;
 		}
 
-
 		p {
-			line-height: 1.5;
-			margin-bottom: $base-size * 0.5;
+			line-height: 1.75;
+			margin-bottom: $base-size * 0.7;
 
 			a {
 				color: $brand-primary;
 			}
+		}
+
+		li {
+			line-height: 1.5;
+			margin-bottom: $base-size * 0.5;
 		}
 
 		table {
@@ -232,6 +236,7 @@
 			font-size: $fontSizeSmall;
 			text-align: center;
 			display: inherit;
+			margin-bottom: $spacingMedium;
 		}
 
 		li > a {


### PR DESCRIPTION
@hold-shift @drakonux  do & don't was on top of the color bar because `do-table` and `dont-table` clases were in use. For images and text we use `do` and `dont`

The paragraph that had almost no line-height was produced by a missing EOL.

From
```
<br/>
In a context where an...
```

to
```
<br/>

In a context where an...
```