### PR TITLE
Use environment property when is set

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,7 +35,7 @@ module.exports = {
 		{
 			resolve: `gatsby-plugin-algolia-docsearch`,
 			options: {
-				apiKey: process.env.ALGOLIA_KEY,
+				apiKey: 'e743f8519124b276f2f3325e8e126246',
 				indexName: 'liferay_design',
 				inputSelector: '#lexicon_search',
 				debug: false,

--- a/src/components/molecules/SearchInput/index.js
+++ b/src/components/molecules/SearchInput/index.js
@@ -25,7 +25,7 @@ export default function SearchInput({ id }) {
 
 	useEffect(() => {
 		window.docsearch({
-			apiKey: process.env.ALGOLIA_KEY,
+			apiKey: process.env.ALGOLIA_KEY || 'e743f8519124b276f2f3325e8e126246',
 			indexName: 'liferay_design',
 			inputSelector: `#${id}`,
 		})

--- a/src/components/molecules/SearchInput/index.js
+++ b/src/components/molecules/SearchInput/index.js
@@ -25,7 +25,7 @@ export default function SearchInput({ id }) {
 
 	useEffect(() => {
 		window.docsearch({
-			apiKey: process.env.ALGOLIA_KEY || 'e743f8519124b276f2f3325e8e126246',
+			apiKey: process.env.GATSBY_ALGOLIA_KEY || 'e743f8519124b276f2f3325e8e126246',
 			indexName: 'liferay_design',
 			inputSelector: `#${id}`,
 		})


### PR DESCRIPTION
Hardcode key. It’s not pretty but that way we are extra sure that it won’t fail if it’s not set-up. 

**And it’s consistent with not needing a key to work at the beginning**, my obsession with properties failed me, sorry :(

Both are needed because `window.docSearch` gets initialized via the plugin with the config key and then it uses the other in every page load with the `useEffect`.