### PR TITLE
Lexicon Site: Remove wrong semantics

### DIFF
--- a/src/markdown/lexicon/core-components/forms/forms-validation.md
+++ b/src/markdown/lexicon/core-components/forms/forms-validation.md
@@ -80,12 +80,3 @@ Additionally, when the submit action is triggered the focus must be located on t
 
 
 ![A form with an error summary on top describing the errors below](/images/lexicon/FormValidationSummary.png)
-
-**Semantics**
-
-| Form Element | Tag |
-| ----------------------------- | :----------: |
-| Title                         | H2           |
-| Summary                       | H1           |
-| Section                       | H3           |
-| Input/Checkbox/Radio/Selector | Use label    |


### PR DESCRIPTION
Remove wrong semantics table.

The semantics are not correctly defined and depends on the context so it is better to remove the section