### PR TITLE
Add contrast white and black to ColorSwatch component

### DIFF
--- a/src/components/molecules/ColorSwatch/index.js
+++ b/src/components/molecules/ColorSwatch/index.js
@@ -14,7 +14,26 @@ export default function ColorSwatch({
 	name,
 	cmyk,
 	pms,
+	contrasted,
 }) {
+	const ContrastedElement = () => {
+		switch (contrasted) {
+			case 'white':
+				return <div className="contrastCircle" />
+			case 'black':
+				return <div className="contrastCircle black" />
+			case 'both':
+				return (
+					<>
+						<div className="contrastCircle" />
+						<div className="contrastCircle black" />
+					</>
+				)
+			default:
+				return null
+		}
+	}
+
 	return (
 		<Flex className={styles.container} direction="column" width="100%">
 			<Flex
@@ -22,7 +41,9 @@ export default function ColorSwatch({
 				height="0"
 				padding="0 0 56.25%"
 				width="100%"
-			/>
+			>
+				<ContrastedElement />
+			</Flex>
 
 			<Flex direction="column" padding="1rem">
 				<Text type="p" weight="heavy" margin="micro" size="base">

--- a/src/markdown/lexicon/foundations/color.mdx
+++ b/src/markdown/lexicon/foundations/color.mdx
@@ -144,6 +144,7 @@ Primary colors define part of Lexicon's visual identity. These colors have been 
 		name="primaryl0"
 		title="Primary L0"
 		smallText=" Accessible 3:1"
+		contrasted="both"
 	/>
 	<ColorSwatch
 		hex="80ACFF"
@@ -263,6 +264,7 @@ Color does have meaning in certain contexts &mdash; in very specific use-cases, 
 		name="mainl0"
 		title="Secondary L0"
 		smallText=" Accessible 3:1"
+		contrasted="both"
 	/>
 	<ColorSwatch
 		hex="A7A9BC"

--- a/src/theme/global.scss
+++ b/src/theme/global.scss
@@ -87,6 +87,27 @@ img {
 	margin-bottom: 46px;
 }
 
+.contrastCircle {
+	color: white;
+	margin: 12px 0 0 12px;
+	border: 1px solid white;
+	font-size: 10px;
+	height: 24px;
+	width: 24px;
+	text-align: center;
+	border-radius: 20px !important;
+	padding-top: 5px;
+
+	&::after {
+		content: '3:1';
+	}
+
+	&.black {
+		color: black;
+		border-color: black;
+	}
+}
+
 .small {
 	font-size: 80%;
 }

--- a/src/theme/lexicon.module.scss
+++ b/src/theme/lexicon.module.scss
@@ -313,11 +313,10 @@
 :global(.example-text) {
 	color: $main-l3;
 	font-size: 14px;
-
-} 
+}
 
 :global(.adapting-columns) {
-    column-count: 3;
+	column-count: 3;
 }
 
 :global(.adapting-columns-2) {
@@ -370,7 +369,6 @@
 	border-color: $info-l1;
 	color: $info;
 }
-
 
 :global(.link-false) {
 	color: $primary;


### PR DESCRIPTION
Example of minimal 3:1 contrast in black and white for accessible colors:

<img width="328" alt="image" src="https://github.com/user-attachments/assets/adcd6338-43b4-4b4f-b21a-6c63c0b9133e">
