### PR TITLE
Fix Lexicon search redirects to legacy domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ yarn-error.log
 
 # token file
 token.json
+
+# Claude / AI agent artifacts
+.claude/

--- a/src/components/molecules/SearchInput/index.js
+++ b/src/components/molecules/SearchInput/index.js
@@ -28,6 +28,23 @@ export default function SearchInput({ id }) {
 			apiKey: process.env.GATSBY_ALGOLIA_KEY || 'e743f8519124b276f2f3325e8e126246',
 			indexName: 'liferay_design',
 			inputSelector: `#${id}`,
+			handleSelected: (input, event, suggestion) => {
+				if (event) {
+					event.preventDefault()
+				}
+
+				const rawUrl = suggestion && suggestion.url ? suggestion.url : ''
+
+				try {
+					const url = new URL(rawUrl, window.location.origin)
+					url.protocol = window.location.protocol
+					url.host = window.location.host
+					window.location.assign(url.toString())
+				} catch (err) {
+					// If parsing fails, fall back to the default behavior.
+					window.location.assign(rawUrl)
+				}
+			},
 		})
 	}, [id])
 


### PR DESCRIPTION
## Summary
- Prevent Lexicon DocSearch results from sending users to the legacy `liferay.design` domain.
- Force selected DocSearch result URLs to use the current site host (e.g. `design.liferay.com`).

## Test plan
- Go to a Lexicon page with the sidebar search.
- Search for any term and click a result.
- Confirm navigation stays on `design.liferay.com` (not `liferay.design`).