### PR TITLE
Add SRI integrity hashes to third-party CDN scripts

### DIFF
--- a/plugins/gatsby-plugin-algolia-docsearch/gatsby-ssr.js
+++ b/plugins/gatsby-plugin-algolia-docsearch/gatsby-ssr.js
@@ -1,0 +1,25 @@
+const React = require('react')
+
+const DOCSEARCH_VERSION = '2.6.3'
+const DOCSEARCH_BASE = `https://cdn.jsdelivr.net/npm/docsearch.js@${DOCSEARCH_VERSION}/dist/cdn`
+
+const CSS_SRI = 'sha384-m2ikRCzP5EF96BXBKTjWxBJqZRlS6qNhm7+rE2Rvl8fIkEANrThfw+EVyeePWhM4'
+const JS_SRI = 'sha384-8uEk67aWSZHvjtAX9hf2AB+KzYcssy31vRRTi9oP81zHtyIj7PQGAykGbQpB1L2J'
+
+exports.onRenderBody = ({ setHeadComponents }) => {
+	setHeadComponents([
+		React.createElement('link', {
+			key: 'docsearch-css',
+			rel: 'stylesheet',
+			href: `${DOCSEARCH_BASE}/docsearch.min.css`,
+			integrity: CSS_SRI,
+			crossOrigin: 'anonymous',
+		}),
+		React.createElement('script', {
+			key: 'docsearch-js',
+			src: `${DOCSEARCH_BASE}/docsearch.min.js`,
+			integrity: JS_SRI,
+			crossOrigin: 'anonymous',
+		}),
+	])
+}

--- a/plugins/gatsby-plugin-algolia-docsearch/package.json
+++ b/plugins/gatsby-plugin-algolia-docsearch/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "gatsby-plugin-algolia-docsearch",
+  "version": "1.0.5",
+  "description": "Local override of gatsby-plugin-algolia-docsearch with SRI support",
+  "main": "gatsby-ssr.js",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ]
+}

--- a/src/html.js
+++ b/src/html.js
@@ -21,7 +21,7 @@ export default class HTML extends React.Component {
 					<title>{seoDescription}</title>
 
 					{this.props.headComponents}
-          <script src="https://cdn.usefathom.com/script.js" data-spa="auto" data-site="LYRINPGJ" defer></script>
+          <script src="https://cdn.usefathom.com/script.js" integrity="sha384-K7To5/+kH06F3upkX8HG8oY/qc2dtF2zk/kWhbKI4FgKlHYIogq0oftSeWXTX4xn" crossOrigin="anonymous" data-spa="auto" data-site="LYRINPGJ" defer></script>
 				</head>
 				<body {...this.props.bodyAttributes}>
 					<StrictMode>

--- a/src/utils/logRocket.js
+++ b/src/utils/logRocket.js
@@ -11,6 +11,7 @@ export class LogRocket extends Component {
 			<Helmet>
 				<script
 					src="https://cdn.lr-ingest.io/LogRocket.min.js"
+					integrity="sha384-b0XbgzE6J/qtc+4HLtAb/hJlDBpi4wFgJu6KmnqBMSxJQG0VrkHjKb+DDaxpAjdN"
 					crossorigin="anonymous"
 				/>
 			</Helmet>


### PR DESCRIPTION
## Summary

- **Fathom analytics** (`src/html.js`): added `integrity` and `crossOrigin` attributes
- **LogRocket** (`src/utils/logRocket.js`): added `integrity` attribute (already had `crossorigin`)
- **DocSearch CSS + JS** (`plugins/gatsby-plugin-algolia-docsearch/`): created a local plugin override that pins docsearch to the exact version `2.6.3` and adds `integrity`/`crossOrigin` to both the stylesheet link and the script tag

The local plugin in `plugins/` takes precedence over the npm package in `node_modules/`, so no `gatsby-config.js` changes were needed.

**Note on hash maintenance**: LogRocket and Fathom deliver scripts from CDNs they control and may update without versioning. If either provider updates their file, the browser will block it (SRI mismatch) and the respective tool will stop working until the hash is updated.

## Test plan
- [ ] Build the site locally and confirm no SRI errors in browser console
- [ ] Confirm Fathom, LogRocket, and DocSearch still function correctly
- [ ] Verify security scanner no longer flags these resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)