### PR TITLE
Animate the hero headline and the footer mural

### DIFF
--- a/src/components/molecules/FancyFooter/index.js
+++ b/src/components/molecules/FancyFooter/index.js
@@ -70,92 +70,140 @@ export default class FancyFooter extends Component {
 						<path
 							d="M480 480v240H240c0-132.548 107.452-240 240-240z"
 							fill="#EEE"
+							className={styles.pie}
+							data-seq="1"
 						/>
 						<path
 							d="M960 480h240v240c-132.55 0-240-107.452-240-240z"
 							fill="#C4C4C4"
+							className={styles.pie}
+							data-seq="2"
 						/>
 						<path
-							d="M1440 240h-240v480c132.55 0 240-107.452 240-240V240zM720 480c-132.548 0-240-107.452-240-240S587.452 0 720 0s240 107.452 240 240H720v240z"
+							d="M1440 240h-240v480c132.55 0 240-107.452 240-240V240z"
 							fill="#232225"
+							className={styles.pie}
+							data-seq="3"
+						/>
+						<path
+							d="M720 480c-132.548 0-240-107.452-240-240S587.452 0 720 0s240 107.452 240 240H720v240z"
+							fill="#232225"
+							className={styles.pie}
+							data-seq="4"
 						/>
 						<path
 							d="M240 480H0V240c132.548 0 240 107.452 240 240z"
 							fill="#0058FF"
+							className={styles.pie}
+							data-seq="5"
 						/>
-						<circle cx="120" cy="120" r="60" fill="#232225" />
-						<circle cx="840" cy="600" r="48" fill="#232225" />
+						<circle
+							cx="120"
+							cy="120"
+							r="60"
+							fill="#232225"
+							className={styles.breathe}
+							data-seq="1"
+						/>
+						<circle
+							cx="840"
+							cy="600"
+							r="48"
+							fill="#232225"
+							className={styles.breathe}
+							data-seq="2"
+						/>
 						<path
 							d="M600 240c0-66.274 53.726-120 120-120v240c-66.274 0-120-53.726-120-120z"
 							fill="#0058FF"
+							className={styles.pie}
+							data-seq="6"
 						/>
 						<path
 							d="M840 240H720V120c66.274 0 120 53.726 120 120z"
 							fill="#0084FF"
+							className={styles.beacon}
 						/>
 						<path
 							d="M80 480H0v-80c44.183 0 80 35.817 80 80z"
 							fill="#232225"
+							className={styles.pie}
+							data-seq="7"
 						/>
 						<g className={styles.stroke}>
 							{' '}
 							<path
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.lineFlow}`}
+								data-seq="1"
+								pathLength="1"
 								d="M130 120h110"
 							/>
 							<path
-								className={styles.whiteStroke}
+								className={`${styles.whiteStroke} ${styles.lineFlow}`}
+								data-seq="2"
+								pathLength="1"
 								d="M1310 360h-110M350 120H240M1310 600h-110"
 							/>
 							<path
-								className={styles.darkStroke}
+								className={`${styles.darkStroke} ${styles.lineFlow}`}
+								data-seq="3"
+								pathLength="1"
 								d="M1090 600h110M1090 360h110"
 							/>
 							<path
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.lineFlow}`}
+								data-seq="4"
+								pathLength="1"
 								d="M360 350V240"
 							/>
 							<circle
 								cx="120"
 								cy="120"
 								r="9"
-								className={styles.whiteStroke}
+								className={`${styles.whiteStroke} ${styles.node}`}
+								data-seq="1"
 							/>
 							<circle
 								cx="360"
 								cy="360"
 								r="9"
-								className={styles.whiteStroke}
+								className={`${styles.whiteStroke} ${styles.node}`}
+								data-seq="3"
 							/>
 							<circle
 								cx="360"
 								cy="120"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="2"
 							/>
 							<circle
 								cx="1320"
 								cy="360"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="5"
 							/>
 							<circle
 								cx="1080"
 								cy="360"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="4"
 							/>
 							<circle
 								cx="1320"
 								cy="600"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="7"
 							/>
 							<circle
 								cx="1080"
 								cy="600"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="6"
 							/>
 							<g clipPath="url(#clip1)">
 								<circle
@@ -164,6 +212,9 @@ export default class FancyFooter extends Component {
 									r="120"
 									transform="rotate(-180 240 240)"
 									stroke="#fff"
+									pathLength="1"
+									className={styles.arcDraw}
+									data-seq="1"
 								/>
 							</g>
 							<g clipPath="url(#clip2)">
@@ -173,6 +224,9 @@ export default class FancyFooter extends Component {
 									r="120"
 									transform="rotate(-180 1200 480)"
 									stroke="#fff"
+									pathLength="1"
+									className={styles.arcDraw}
+									data-seq="2"
 								/>
 							</g>
 							<g clipPath="url(#clip3)">
@@ -182,6 +236,9 @@ export default class FancyFooter extends Component {
 									r="120"
 									transform="rotate(-90 1200 480)"
 									stroke="#fff"
+									pathLength="1"
+									className={styles.arcDraw}
+									data-seq="3"
 								/>
 							</g>
 							<g clipPath="url(#clip4)">
@@ -190,13 +247,62 @@ export default class FancyFooter extends Component {
 									cy="480"
 									r="120"
 									stroke="#232225"
+									pathLength="1"
+									className={styles.arcDraw}
+									data-seq="4"
 								/>
 							</g>
 						</g>
-						<path
-							fill="#0058FF"
-							d="M248 128h-16v-16h16zM368 248h-16v-16h16zM1208 368h-16v-16h16zM1328 488h-16v-16h16zM1192 592h16v16h-16zM1072 472h16v16h-16z"
-						/>
+						<g fill="#0058FF">
+							<rect
+								x="232"
+								y="112"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="1"
+							/>
+							<rect
+								x="352"
+								y="232"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="2"
+							/>
+							<rect
+								x="1192"
+								y="352"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="3"
+							/>
+							<rect
+								x="1312"
+								y="472"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="4"
+							/>
+							<rect
+								x="1192"
+								y="592"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="5"
+							/>
+							<rect
+								x="1072"
+								y="472"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="6"
+							/>
+						</g>
 						<g fill="#0058ff" className={styles.dotCircle}>
 							<rect
 								x="40"
@@ -223,6 +329,7 @@ export default class FancyFooter extends Component {
 							stroke="#13141F"
 							strokeWidth="6"
 							strokeDasharray="3 12"
+							className={styles.dashMarch}
 						/>
 						<rect
 							x="1204"
@@ -230,6 +337,7 @@ export default class FancyFooter extends Component {
 							fill="url(#dots)"
 							width="240"
 							height="200"
+							className={styles.dotsDrift}
 						/>
 					</g>
 				</svg>

--- a/src/components/molecules/FancyFooter/styles.module.scss
+++ b/src/components/molecules/FancyFooter/styles.module.scss
@@ -39,3 +39,202 @@
 		}
 	}
 }
+
+// Living mural: every element family moves continuously with soft easing
+// and short, overlapping cycles — no long rest slots.
+@media (prefers-reduced-motion: no-preference) {
+	// Solid pies and rounds breathe from their corner anchor, phase-shifted
+	// so a soft wave crosses the whole mural.
+	.pie {
+		transform-box: view-box;
+		animation: pieBreathe 5s ease-in-out infinite alternate;
+
+		// transform origins = each shape's right-angle corner / disc center
+		&[data-seq='1'] {
+			transform-origin: 480px 720px;
+		}
+		&[data-seq='2'] {
+			transform-origin: 1200px 480px;
+		}
+		&[data-seq='3'] {
+			transform-origin: 1320px 480px;
+		}
+		&[data-seq='4'] {
+			transform-origin: 720px 240px;
+		}
+		&[data-seq='5'] {
+			transform-origin: 0px 480px;
+		}
+		&[data-seq='6'] {
+			transform-origin: 720px 240px;
+		}
+		&[data-seq='7'] {
+			transform-origin: 0px 480px;
+		}
+		@for $i from 1 through 7 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * -0.7}s;
+			}
+		}
+	}
+
+	// The light-blue quarter glows like a beacon — chromatic motion only
+	.beacon {
+		animation: beaconGlow 4s ease-in-out infinite alternate;
+	}
+
+	// Connector nodes pulse in a left-to-right wave
+	.node {
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: nodePulse 6s ease-in-out infinite;
+
+		@for $i from 1 through 7 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * 0.35}s;
+			}
+		}
+	}
+
+	// A signal gap travels along the connector lines
+	.lineFlow {
+		stroke-dasharray: 0.82 0.18;
+		animation: lineFlow 3.5s linear infinite;
+
+		@for $i from 1 through 4 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * -0.9}s;
+			}
+		}
+	}
+
+	// A comet gap orbits each quarter arc continuously
+	.arcDraw {
+		stroke-dasharray: 0.88 0.12;
+		animation: lineFlow 7s linear infinite;
+
+		@for $i from 1 through 4 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * -1.75}s;
+			}
+		}
+	}
+
+	// Blue accents quarter-turn like clockwork, one tick each, staggered.
+	// A square rotated 90deg looks identical, so the loop reset is seamless.
+	.miniSquare {
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: quarterTurn 5s ease-in-out infinite;
+
+		@for $i from 1 through 6 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * 0.8}s;
+			}
+		}
+	}
+
+	// Filled circles breathe in counter-phase
+	.breathe {
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: breathe 4s ease-in-out infinite alternate;
+
+		&[data-seq='2'] {
+			animation-delay: -2s;
+		}
+	}
+
+	.dashMarch {
+		// dash period is 3 + 12 = 15, so a -15 shift loops seamlessly
+		animation: dashMarch 1.8s linear infinite;
+	}
+
+	.dotCircle {
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: gentleFloat 4.5s ease-in-out infinite alternate;
+	}
+
+	.dotsDrift {
+		animation: dotsBreathe 4.5s ease-in-out infinite alternate;
+	}
+
+	@keyframes pieBreathe {
+		from {
+			transform: scale(1);
+		}
+		to {
+			transform: scale(1.035);
+		}
+	}
+
+	@keyframes beaconGlow {
+		from {
+			fill: #0084ff;
+		}
+		to {
+			fill: #3db5ff;
+		}
+	}
+
+	@keyframes nodePulse {
+		0%,
+		30%,
+		100% {
+			transform: scale(1);
+		}
+		15% {
+			transform: scale(1.45);
+		}
+	}
+
+	@keyframes lineFlow {
+		to {
+			stroke-dashoffset: -1;
+		}
+	}
+
+	@keyframes quarterTurn {
+		0%,
+		78% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(90deg);
+		}
+	}
+
+	@keyframes breathe {
+		from {
+			transform: scale(1);
+		}
+		to {
+			transform: scale(1.09);
+		}
+	}
+
+	@keyframes dashMarch {
+		to {
+			stroke-dashoffset: -15;
+		}
+	}
+
+	@keyframes gentleFloat {
+		from {
+			transform: translateY(2px);
+		}
+		to {
+			transform: translateY(-6px);
+		}
+	}
+
+	@keyframes dotsBreathe {
+		from {
+			opacity: 0.5;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+}

--- a/src/components/organisms/HeroBanner/index.js
+++ b/src/components/organisms/HeroBanner/index.js
@@ -1,37 +1,25 @@
-/** @jsx jsx */
-
-import { jsx, Flex, Text } from 'theme-ui'
+import React from 'react'
+import styles from './styles.module.scss'
 
 const HeroBanner = () => (
-	<Flex
-		sx={{
-			alignItems: 'center',
-			justifyContent: ['flex-start', 'center', null],
-			height: ['40vh', '448px', null],
-			margin: '0 auto',
-			pl: [3, 0, null],
-			minWidth: '360px',
-			position: 'relative',
-			width: '100vw',
-			maxWidth: '100%',
-		}}
-	>
-		<Text
-			as="h1"
-			sx={{
-				width: ['14ch', '20ch', null],
-				fontSize: [5, 6, null],
-				fontWeight: 'heading',
-				color: 'white',
-			}}
-		>
-			We are{' '}
-			<Text as="span" sx={{ color: 'neutral1' }}>
-				Liferayʼs global team of{' '}
-			</Text>
-			designers.
-		</Text>
-	</Flex>
+	<div className={styles.heroBanner}>
+		<h1 className={styles.headline}>
+			<span className={styles.line}>
+				<span className={styles.word}>We are </span>
+			</span>
+			<span className={styles.line}>
+				<span className={`${styles.word} ${styles.accent}`}>
+					Liferayʼs global team{' '}
+				</span>
+			</span>
+			<span className={styles.line}>
+				<span className={styles.word}>
+					of designers.
+					<span className={styles.bar} />
+				</span>
+			</span>
+		</h1>
+	</div>
 )
 
 export default HeroBanner

--- a/src/components/organisms/HeroBanner/styles.module.scss
+++ b/src/components/organisms/HeroBanner/styles.module.scss
@@ -1,0 +1,101 @@
+@import '~theme/variables';
+
+.heroBanner {
+	align-items: center;
+	display: flex;
+	justify-content: flex-start;
+	margin: 0 auto;
+	max-width: 100%;
+	min-height: 40vh;
+	min-width: 360px;
+	padding: $spacingBase $spacingSmall;
+	position: relative;
+	width: 100vw;
+
+	@media screen and (min-width: $screenSmall) {
+		justify-content: center;
+		min-height: 448px;
+	}
+}
+
+.headline {
+	color: $white;
+	// fluid: ~40px on small phones up to ~76px on wide screens
+	font-size: clamp(2.5rem, 4.5vw + 1.25rem, 4.75rem);
+	font-weight: $fontWeightBlack;
+	letter-spacing: -0.02em;
+	line-height: 1.08;
+	margin: 0;
+	max-width: 18ch;
+}
+
+.line {
+	display: block;
+	overflow: hidden;
+	padding-bottom: 0.08em; // keep descenders visible inside the mask
+}
+
+.word {
+	display: inline-block;
+	will-change: transform;
+}
+
+.accent {
+	// tone-on-tone: the page background ($black #13141f) lightened along its
+	// own hue until it clears 3:1 against it (WCAG AA for large text)
+	color: lighten($black, 41%);
+}
+
+.bar {
+	background: $primary;
+	border-radius: 2px;
+	display: block;
+	height: 0.075em;
+	margin-top: 0.12em;
+	transform: scaleX(0);
+	transform-origin: left;
+	width: 38%;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.word {
+		animation: heroRise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+	}
+
+	.line:nth-child(1) .word {
+		animation-delay: 0.1s;
+	}
+	.line:nth-child(2) .word {
+		animation-delay: 0.28s;
+	}
+	.line:nth-child(3) .word {
+		animation-delay: 0.46s;
+	}
+
+	.bar {
+		animation: heroBar 0.7s cubic-bezier(0.22, 1, 0.36, 1) 1.05s both;
+	}
+
+	@keyframes heroRise {
+		from {
+			opacity: 0;
+			transform: translateY(115%);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	@keyframes heroBar {
+		to {
+			transform: scaleX(1);
+		}
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.bar {
+		transform: scaleX(1);
+	}
+}


### PR DESCRIPTION
## What

Two motion refinements to the most distinctive visual pieces of the site, both pure CSS/SVG — no new dependencies, works on the current stack and on the Gatsby 3 branch (#1322) alike.

### Hero headline (home)

- Staggered entrance: each line of *"We are / Liferayʼs global team / of designers."* rises from an overflow mask with a soft ease, then a brand-blue bar draws under the closing line
- Fluid type via `clamp()` so the headline adapts to the hero space from mobile to wide screens
- **Contrast fix**: the middle segment was `neutral1` (#2c3a4b) on the near-black background — far below WCAG minimums. It is now a tone-on-tone accent derived from the background itself (`lighten(#13141f, 41%)`), tuned to ~3:1, the AA threshold for large text

### Footer mural (FancyFooter)

The Bauhaus-style SVG mural now lives: quarter shapes breathe from their corner anchors in a phase-shifted wave, nodes pulse in cascade, a signal gap travels the connector lines, comet gaps orbit the arcs, the small blue squares quarter-turn like clockwork (loop reset is seamless since a square is rotation-symmetric), the light-blue quarter glows between brand blues, the dot grid floats and the dashed line marches.

The six accent squares were a single `<path>`; they are split into individual `<rect>`s so each can animate on its own.

## Accessibility

All motion is gated behind `@media (prefers-reduced-motion: no-preference)` — users who ask for reduced motion get the exact static design as today.

## Notes

Independent of #1322; either can merge first. More site-wide design work (Lexicon dark mode, contrast pass) is in progress and will come as separate PRs.