### PR TITLE
Site polish: hero + footer animations, navbar consistency, accessibility & contrast

### DIFF
--- a/src/components/atoms/Heading/index.js
+++ b/src/components/atoms/Heading/index.js
@@ -36,7 +36,10 @@ Heading.propTypes = {
 Heading.defaultProps = {
 	className: '',
 	level: 3,
-	textAlign: 'left',
+	// was `textAlign: 'left'` — not a destructured prop, so it leaked onto the
+	// DOM node as an invalid `textAlign` attribute. The component consumes
+	// `align` for text alignment.
+	align: 'left',
 }
 
 export default Heading

--- a/src/components/molecules/Accordion/index.js
+++ b/src/components/molecules/Accordion/index.js
@@ -19,7 +19,9 @@ export default class Accordion extends Component {
 
 	render() {
 		return (
-			<ul className={styles.accordion}>
+			// a disclosure widget, not a semantic list — a <ul> here only ever
+			// held a Flex + a div, which fails "lists structured correctly"
+			<div className={styles.accordion}>
 				<Flex
 					align="center"
 					onClick={this.toggleVisibility}
@@ -52,7 +54,7 @@ export default class Accordion extends Component {
 				>
 					{this.props.children}
 				</div>
-			</ul>
+			</div>
 		)
 	}
 }

--- a/src/components/molecules/Billboard/styles.module.scss
+++ b/src/components/molecules/Billboard/styles.module.scss
@@ -14,6 +14,11 @@
 	.icon {
 		grid-area: icon;
 		justify-self: center;
+		// on mobile the icon spans the grid column and touches the screen
+		// edges — keep it off the margins
+		@media screen and (max-width: $screenMedium) {
+			padding: 0 $spacingBase;
+		}
 	}
 	.copy {
 		grid-area: copy;

--- a/src/components/molecules/CardDefault/index.js
+++ b/src/components/molecules/CardDefault/index.js
@@ -31,7 +31,7 @@ const CardDefault = ({
 				className={styles.cardLink}
 				to={link}
 				sx={{
-					'&:hover > div > div > img:nth-child(2)': {
+					'&:hover > div > div > img:nth-of-type(2)': {
 						filter: 'grayscale(0)',
 					},
 					'&:hover > div > div': {

--- a/src/components/molecules/CardDefault/styles.module.scss
+++ b/src/components/molecules/CardDefault/styles.module.scss
@@ -1,10 +1,20 @@
 @import '~theme/variables';
 
 .cardLink {
-	&:hover {
+	border-radius: 2em; // match the card so the keyboard ring hugs it
+	// keyboard-only focus: mirror the hover glow + lift and add a clear ring
+	&:hover,
+	&:focus-visible {
 		.sexyShadow {
 			opacity: 0.64;
 			transition: opacity 0.2s ease-in-out;
+		}
+	}
+	&:focus-visible {
+		outline: 3px solid $primary;
+		outline-offset: 6px;
+		.card {
+			transform: translateY(-0.2rem);
 		}
 	}
 	.sexyShadow {

--- a/src/components/molecules/CardHidden/styles.module.scss
+++ b/src/components/molecules/CardHidden/styles.module.scss
@@ -58,12 +58,12 @@
 
 		p.text {
 			font-weight: $fontWeightRegular;
-			color: $main-l4;
+			color: $main-l3;
 			margin: 0 0 1em;
 		}
 
 		p.cta {
-			color: lighten($main-l4, 16%);
+			color: $main-l3;
 			transition: color 0.4s;
 		}
 

--- a/src/components/molecules/CardLexicon/index.js
+++ b/src/components/molecules/CardLexicon/index.js
@@ -77,6 +77,7 @@ const CardLexicon = ({
 						>
 							<Icon
 								name={icon}
+								aria-hidden="true"
 								sx={{
 									width: `${iconWidth}`,
 									height: `${iconHeight}`,

--- a/src/components/molecules/CardLexicon/index.js
+++ b/src/components/molecules/CardLexicon/index.js
@@ -37,6 +37,13 @@ const CardLexicon = ({
 		horizontal: 'left',
 	}
 
+	// the heading must follow the same alignment as the copy block, otherwise
+	// the Heading atom's default `align: left` leaves the title left-aligned
+	// inside a centered card
+	const copyAlign = isMobile
+		? textAlignmentMap.vertical
+		: textAlignmentMap[direction]
+
 	const iconWidthMap = {
 		vertical: '100%',
 		horizontal: '50%',
@@ -91,16 +98,20 @@ const CardLexicon = ({
 						className={styles.copy}
 						style={{
 							flexBasis: '50%',
-							textAlign: isMobile
-								? textAlignmentMap.vertical
-								: textAlignmentMap[direction],
+							textAlign: copyAlign,
 							alignSelf: 'center',
 						}}
 					>
 						{preTitle ? (
-							<Heading className={styles.preTitle}>{preTitle}</Heading>
+							<Heading align={copyAlign} className={styles.preTitle}>
+								{preTitle}
+							</Heading>
 						) : null}
-						<Heading level={2} className={styles.title}>
+						<Heading
+							align={copyAlign}
+							level={2}
+							className={styles.title}
+						>
 							{title}
 						</Heading>
 						<Text type="p" size="medium" className={styles.text}>

--- a/src/components/molecules/CardLexicon/styles.module.scss
+++ b/src/components/molecules/CardLexicon/styles.module.scss
@@ -36,6 +36,10 @@
 	p.text {
 		color: $lightestGrey !important;
 	}
+	p.cta {
+		// the light-card cta colour ($main-l3) is unreadable on the dark card
+		color: $primary-l1 !important;
+	}
 }
 
 .card.wide {
@@ -102,13 +106,13 @@
 
 	p.text {
 		font-weight: $fontWeightRegular;
-		color: $main-l4;
+		color: $main-l3;
 		font-size: $fontSizeMedium;
 		margin: 0 0 $fontSizeXLarge;
 	}
 
 	p.cta {
-		color: lighten($main-l4, 16%);
+		color: $main-l3;
 	}
 }
 @media screen and (max-width: $screenMedium) {

--- a/src/components/molecules/FancyFooter/index.js
+++ b/src/components/molecules/FancyFooter/index.js
@@ -12,7 +12,7 @@ export default class FancyFooter extends Component {
 
 	render() {
 		return (
-			<div className={styles.fancyFooter}>
+			<div className={styles.fancyFooter} aria-hidden="true">
 				<svg
 					viewBox="0 0 1440 720"
 					fill="none"
@@ -70,92 +70,140 @@ export default class FancyFooter extends Component {
 						<path
 							d="M480 480v240H240c0-132.548 107.452-240 240-240z"
 							fill="#EEE"
+							className={styles.pie}
+							data-seq="1"
 						/>
 						<path
 							d="M960 480h240v240c-132.55 0-240-107.452-240-240z"
 							fill="#C4C4C4"
+							className={styles.pie}
+							data-seq="2"
 						/>
 						<path
-							d="M1440 240h-240v480c132.55 0 240-107.452 240-240V240zM720 480c-132.548 0-240-107.452-240-240S587.452 0 720 0s240 107.452 240 240H720v240z"
+							d="M1440 240h-240v480c132.55 0 240-107.452 240-240V240z"
 							fill="#232225"
+							className={styles.pie}
+							data-seq="3"
+						/>
+						<path
+							d="M720 480c-132.548 0-240-107.452-240-240S587.452 0 720 0s240 107.452 240 240H720v240z"
+							fill="#232225"
+							className={styles.pie}
+							data-seq="4"
 						/>
 						<path
 							d="M240 480H0V240c132.548 0 240 107.452 240 240z"
 							fill="#0058FF"
+							className={styles.pie}
+							data-seq="5"
 						/>
-						<circle cx="120" cy="120" r="60" fill="#232225" />
-						<circle cx="840" cy="600" r="48" fill="#232225" />
+						<circle
+							cx="120"
+							cy="120"
+							r="60"
+							fill="#232225"
+							className={styles.breathe}
+							data-seq="1"
+						/>
+						<circle
+							cx="840"
+							cy="600"
+							r="48"
+							fill="#232225"
+							className={styles.breathe}
+							data-seq="2"
+						/>
 						<path
 							d="M600 240c0-66.274 53.726-120 120-120v240c-66.274 0-120-53.726-120-120z"
 							fill="#0058FF"
+							className={styles.pie}
+							data-seq="6"
 						/>
 						<path
 							d="M840 240H720V120c66.274 0 120 53.726 120 120z"
 							fill="#0084FF"
+							className={styles.beacon}
 						/>
 						<path
 							d="M80 480H0v-80c44.183 0 80 35.817 80 80z"
 							fill="#232225"
+							className={styles.pie}
+							data-seq="7"
 						/>
 						<g className={styles.stroke}>
 							{' '}
 							<path
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.lineFlow}`}
+								data-seq="1"
+								pathLength="1"
 								d="M130 120h110"
 							/>
 							<path
-								className={styles.whiteStroke}
+								className={`${styles.whiteStroke} ${styles.lineFlow}`}
+								data-seq="2"
+								pathLength="1"
 								d="M1310 360h-110M350 120H240M1310 600h-110"
 							/>
 							<path
-								className={styles.darkStroke}
+								className={`${styles.darkStroke} ${styles.lineFlow}`}
+								data-seq="3"
+								pathLength="1"
 								d="M1090 600h110M1090 360h110"
 							/>
 							<path
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.lineFlow}`}
+								data-seq="4"
+								pathLength="1"
 								d="M360 350V240"
 							/>
 							<circle
 								cx="120"
 								cy="120"
 								r="9"
-								className={styles.whiteStroke}
+								className={`${styles.whiteStroke} ${styles.node}`}
+								data-seq="1"
 							/>
 							<circle
 								cx="360"
 								cy="360"
 								r="9"
-								className={styles.whiteStroke}
+								className={`${styles.whiteStroke} ${styles.node}`}
+								data-seq="3"
 							/>
 							<circle
 								cx="360"
 								cy="120"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="2"
 							/>
 							<circle
 								cx="1320"
 								cy="360"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="5"
 							/>
 							<circle
 								cx="1080"
 								cy="360"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="4"
 							/>
 							<circle
 								cx="1320"
 								cy="600"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="7"
 							/>
 							<circle
 								cx="1080"
 								cy="600"
 								r="9"
-								className={styles.primaryStroke}
+								className={`${styles.primaryStroke} ${styles.node}`}
+								data-seq="6"
 							/>
 							<g clipPath="url(#clip1)">
 								<circle
@@ -164,6 +212,9 @@ export default class FancyFooter extends Component {
 									r="120"
 									transform="rotate(-180 240 240)"
 									stroke="#fff"
+									pathLength="1"
+									className={styles.arcDraw}
+									data-seq="1"
 								/>
 							</g>
 							<g clipPath="url(#clip2)">
@@ -173,6 +224,9 @@ export default class FancyFooter extends Component {
 									r="120"
 									transform="rotate(-180 1200 480)"
 									stroke="#fff"
+									pathLength="1"
+									className={styles.arcDraw}
+									data-seq="2"
 								/>
 							</g>
 							<g clipPath="url(#clip3)">
@@ -182,6 +236,9 @@ export default class FancyFooter extends Component {
 									r="120"
 									transform="rotate(-90 1200 480)"
 									stroke="#fff"
+									pathLength="1"
+									className={styles.arcDraw}
+									data-seq="3"
 								/>
 							</g>
 							<g clipPath="url(#clip4)">
@@ -190,13 +247,62 @@ export default class FancyFooter extends Component {
 									cy="480"
 									r="120"
 									stroke="#232225"
+									pathLength="1"
+									className={styles.arcDraw}
+									data-seq="4"
 								/>
 							</g>
 						</g>
-						<path
-							fill="#0058FF"
-							d="M248 128h-16v-16h16zM368 248h-16v-16h16zM1208 368h-16v-16h16zM1328 488h-16v-16h16zM1192 592h16v16h-16zM1072 472h16v16h-16z"
-						/>
+						<g fill="#0058FF">
+							<rect
+								x="232"
+								y="112"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="1"
+							/>
+							<rect
+								x="352"
+								y="232"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="2"
+							/>
+							<rect
+								x="1192"
+								y="352"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="3"
+							/>
+							<rect
+								x="1312"
+								y="472"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="4"
+							/>
+							<rect
+								x="1192"
+								y="592"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="5"
+							/>
+							<rect
+								x="1072"
+								y="472"
+								width="16"
+								height="16"
+								className={styles.miniSquare}
+								data-seq="6"
+							/>
+						</g>
 						<g fill="#0058ff" className={styles.dotCircle}>
 							<rect
 								x="40"
@@ -223,6 +329,7 @@ export default class FancyFooter extends Component {
 							stroke="#13141F"
 							strokeWidth="6"
 							strokeDasharray="3 12"
+							className={styles.dashMarch}
 						/>
 						<rect
 							x="1204"
@@ -230,6 +337,7 @@ export default class FancyFooter extends Component {
 							fill="url(#dots)"
 							width="240"
 							height="200"
+							className={styles.dotsDrift}
 						/>
 					</g>
 				</svg>

--- a/src/components/molecules/FancyFooter/styles.module.scss
+++ b/src/components/molecules/FancyFooter/styles.module.scss
@@ -39,3 +39,202 @@
 		}
 	}
 }
+
+// Living mural: every element family moves continuously with soft easing
+// and short, overlapping cycles — no long rest slots.
+@media (prefers-reduced-motion: no-preference) {
+	// Solid pies and rounds breathe from their corner anchor, phase-shifted
+	// so a soft wave crosses the whole mural.
+	.pie {
+		transform-box: view-box;
+		animation: pieBreathe 5s ease-in-out infinite alternate;
+
+		// transform origins = each shape's right-angle corner / disc center
+		&[data-seq='1'] {
+			transform-origin: 480px 720px;
+		}
+		&[data-seq='2'] {
+			transform-origin: 1200px 480px;
+		}
+		&[data-seq='3'] {
+			transform-origin: 1320px 480px;
+		}
+		&[data-seq='4'] {
+			transform-origin: 720px 240px;
+		}
+		&[data-seq='5'] {
+			transform-origin: 0px 480px;
+		}
+		&[data-seq='6'] {
+			transform-origin: 720px 240px;
+		}
+		&[data-seq='7'] {
+			transform-origin: 0px 480px;
+		}
+		@for $i from 1 through 7 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * -0.7}s;
+			}
+		}
+	}
+
+	// The light-blue quarter glows like a beacon — chromatic motion only
+	.beacon {
+		animation: beaconGlow 4s ease-in-out infinite alternate;
+	}
+
+	// Connector nodes pulse in a left-to-right wave
+	.node {
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: nodePulse 6s ease-in-out infinite;
+
+		@for $i from 1 through 7 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * 0.35}s;
+			}
+		}
+	}
+
+	// A signal gap travels along the connector lines
+	.lineFlow {
+		stroke-dasharray: 0.82 0.18;
+		animation: lineFlow 3.5s linear infinite;
+
+		@for $i from 1 through 4 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * -0.9}s;
+			}
+		}
+	}
+
+	// A comet gap orbits each quarter arc continuously
+	.arcDraw {
+		stroke-dasharray: 0.88 0.12;
+		animation: lineFlow 7s linear infinite;
+
+		@for $i from 1 through 4 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * -1.75}s;
+			}
+		}
+	}
+
+	// Blue accents quarter-turn like clockwork, one tick each, staggered.
+	// A square rotated 90deg looks identical, so the loop reset is seamless.
+	.miniSquare {
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: quarterTurn 5s ease-in-out infinite;
+
+		@for $i from 1 through 6 {
+			&[data-seq='#{$i}'] {
+				animation-delay: #{($i - 1) * 0.8}s;
+			}
+		}
+	}
+
+	// Filled circles breathe in counter-phase
+	.breathe {
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: breathe 4s ease-in-out infinite alternate;
+
+		&[data-seq='2'] {
+			animation-delay: -2s;
+		}
+	}
+
+	.dashMarch {
+		// dash period is 3 + 12 = 15, so a -15 shift loops seamlessly
+		animation: dashMarch 1.8s linear infinite;
+	}
+
+	.dotCircle {
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: gentleFloat 4.5s ease-in-out infinite alternate;
+	}
+
+	.dotsDrift {
+		animation: dotsBreathe 4.5s ease-in-out infinite alternate;
+	}
+
+	@keyframes pieBreathe {
+		from {
+			transform: scale(1);
+		}
+		to {
+			transform: scale(1.035);
+		}
+	}
+
+	@keyframes beaconGlow {
+		from {
+			fill: #0084ff;
+		}
+		to {
+			fill: #3db5ff;
+		}
+	}
+
+	@keyframes nodePulse {
+		0%,
+		30%,
+		100% {
+			transform: scale(1);
+		}
+		15% {
+			transform: scale(1.45);
+		}
+	}
+
+	@keyframes lineFlow {
+		to {
+			stroke-dashoffset: -1;
+		}
+	}
+
+	@keyframes quarterTurn {
+		0%,
+		78% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(90deg);
+		}
+	}
+
+	@keyframes breathe {
+		from {
+			transform: scale(1);
+		}
+		to {
+			transform: scale(1.09);
+		}
+	}
+
+	@keyframes dashMarch {
+		to {
+			stroke-dashoffset: -15;
+		}
+	}
+
+	@keyframes gentleFloat {
+		from {
+			transform: translateY(2px);
+		}
+		to {
+			transform: translateY(-6px);
+		}
+	}
+
+	@keyframes dotsBreathe {
+		from {
+			opacity: 0.5;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+}

--- a/src/components/molecules/SearchInput/index.js
+++ b/src/components/molecules/SearchInput/index.js
@@ -60,6 +60,7 @@ export default function SearchInput({ id }) {
 				onBlur={showKeys}
 				id={id}
 				placeholder="Search"
+				aria-label="Search Lexicon"
 			/>
 			<Flex
 				sx={{

--- a/src/components/molecules/SearchInput/styles.module.scss
+++ b/src/components/molecules/SearchInput/styles.module.scss
@@ -32,7 +32,7 @@
 	:global .algolia-autocomplete .algolia-docsearch-suggestion--category-header {
 		@include small-caps;
 		padding: $spacingXSmall;
-		color: $main-l4;
+		color: $main-l3;
 		border-bottom: 1px solid $main-l6;
 		font-size: $fontSizeXSmall;
 		letter-spacing: 0.05ch;
@@ -47,7 +47,7 @@
 	/* Description description (eg. Bootstrap currently works...) */
 	:global .algolia-autocomplete .algolia-docsearch-suggestion--text {
 		font-size: 0.8rem;
-		color: $main-l4;
+		color: $main-l3;
 	}
 
 	/* Highlighted text */

--- a/src/components/organisms/Footer/styles.module.scss
+++ b/src/components/organisms/Footer/styles.module.scss
@@ -28,8 +28,13 @@ footer.dark {
 		fill: $white;
 	}
 	a {
-		color: $grey;
-		text-decoration: underline
+		// $grey (#6b6c7e) fails AA on the dark footer; lift to a light neutral
+		color: $lightGrey;
+		text-decoration: underline;
+	}
+	// SiteCredits hardcodes its <span> to $grey, which also fails here
+	span {
+		color: $lightGrey;
 	}
 }
 

--- a/src/components/organisms/HeroBanner/index.js
+++ b/src/components/organisms/HeroBanner/index.js
@@ -1,37 +1,27 @@
-/** @jsx jsx */
-
-import { jsx, Flex, Text } from 'theme-ui'
+import React from 'react'
+import styles from './styles.module.scss'
 
 const HeroBanner = () => (
-	<Flex
-		sx={{
-			alignItems: 'center',
-			justifyContent: ['flex-start', 'center', null],
-			height: ['40vh', '448px', null],
-			margin: '0 auto',
-			pl: [3, 0, null],
-			minWidth: '360px',
-			position: 'relative',
-			width: '100vw',
-			maxWidth: '100%',
-		}}
-	>
-		<Text
-			as="h1"
-			sx={{
-				width: ['14ch', '20ch', null],
-				fontSize: [5, 6, null],
-				fontWeight: 'heading',
-				color: 'white',
-			}}
-		>
-			We are{' '}
-			<Text as="span" sx={{ color: 'neutral1' }}>
-				Liferayʼs global team of{' '}
-			</Text>
-			designers.
-		</Text>
-	</Flex>
+	<div className={styles.heroBanner}>
+		<h1 className={styles.headline}>
+			<span className={styles.line}>
+				<span className={styles.word}>
+					We are <span className={styles.accent}>Liferayʼs</span>
+				</span>
+			</span>
+			<span className={styles.line}>
+				<span className={styles.word}>
+					<span className={styles.accent}>global team</span> of
+				</span>
+			</span>
+			<span className={styles.line}>
+				<span className={styles.word}>
+					designers.
+					<span className={styles.bar} />
+				</span>
+			</span>
+		</h1>
+	</div>
 )
 
 export default HeroBanner

--- a/src/components/organisms/HeroBanner/styles.module.scss
+++ b/src/components/organisms/HeroBanner/styles.module.scss
@@ -8,7 +8,8 @@
 	max-width: 100%;
 	min-height: 40vh;
 	min-width: 360px;
-	padding: $spacingBase $spacingSmall;
+	// roomier horizontal padding so the headline never hugs the screen edges
+	padding: $spacingBase $spacingMedium;
 	position: relative;
 	width: 100vw;
 
@@ -53,7 +54,7 @@
 	border-radius: 2px;
 	display: block;
 	height: 0.075em;
-	margin-top: 0.12em;
+	margin-top: 0.42em;
 	transform: scaleX(0);
 	transform-origin: left;
 	width: 38%;

--- a/src/components/organisms/HeroBanner/styles.module.scss
+++ b/src/components/organisms/HeroBanner/styles.module.scss
@@ -1,0 +1,103 @@
+@import '~theme/variables';
+
+.heroBanner {
+	align-items: center;
+	display: flex;
+	justify-content: flex-start;
+	margin: 0 auto;
+	max-width: 100%;
+	min-height: 40vh;
+	min-width: 360px;
+	padding: $spacingBase $spacingSmall;
+	position: relative;
+	width: 100vw;
+
+	@media screen and (min-width: $screenSmall) {
+		justify-content: center;
+		min-height: 448px;
+	}
+}
+
+.headline {
+	color: $white;
+	// fluid: ~40px on small phones up to ~76px on wide screens
+	font-size: clamp(2.5rem, 4.5vw + 1.25rem, 4.75rem);
+	font-weight: $fontWeightBlack;
+	letter-spacing: -0.02em;
+	line-height: 1.08;
+	margin: 0;
+	max-width: 18ch;
+}
+
+// each line reveals from its own overflow mask
+.line {
+	display: block;
+	overflow: hidden;
+	padding-bottom: 0.08em; // keep descenders (g, y) visible inside the mask
+}
+
+.word {
+	display: inline-block;
+	white-space: nowrap; // the line breaks are intentional, never let one wrap
+	will-change: transform;
+}
+
+.accent {
+	// tone-on-tone: the page background ($black #13141f) lightened along its
+	// own hue until it clears 3:1 against it (WCAG AA for large text)
+	color: lighten($black, 41%);
+}
+
+.bar {
+	background: $primary;
+	border-radius: 2px;
+	display: block;
+	height: 0.075em;
+	margin-top: 0.12em;
+	transform: scaleX(0);
+	transform-origin: left;
+	width: 38%;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.word {
+		animation: heroRise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+	}
+
+	.line:nth-child(1) .word {
+		animation-delay: 0.1s;
+	}
+	.line:nth-child(2) .word {
+		animation-delay: 0.28s;
+	}
+	.line:nth-child(3) .word {
+		animation-delay: 0.46s;
+	}
+
+	.bar {
+		animation: heroBar 0.7s cubic-bezier(0.22, 1, 0.36, 1) 1.05s both;
+	}
+
+	@keyframes heroRise {
+		from {
+			opacity: 0;
+			transform: translateY(115%);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	@keyframes heroBar {
+		to {
+			transform: scaleX(1);
+		}
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.bar {
+		transform: scaleX(1);
+	}
+}

--- a/src/components/organisms/NavItems/index.js
+++ b/src/components/organisms/NavItems/index.js
@@ -4,7 +4,9 @@ import { jsx, NavLink, Flex, Box } from 'theme-ui'
 import { AuthContainer } from 'components/molecules'
 
 const NavItems = () => {
-	const pages = ['Lexicon', 'Articles', 'Events', 'Team', 'Handbook']
+	// Handbook intentionally omitted from the primary nav — it lives as a
+	// discreet link in the footer instead
+	const pages = ['Lexicon', 'Articles', 'Events', 'Team']
 
 	return (
 		<Flex align="center">

--- a/src/components/organisms/Navbar/index.js
+++ b/src/components/organisms/Navbar/index.js
@@ -10,7 +10,7 @@ import { AuthContainer } from 'components/molecules'
 const Navbar = ({ white, section, underlineColor, simpleNav }) => {
 	return (
 		<Container>
-			<nav className={white ? styles.white : styles.default}>
+			<nav className={`${styles.navbar} ${white ? styles.white : ''}`}>
 				{simpleNav ? (
 					<Link style={{ alignSelf: 'center', marginLeft: '-.2rem' }} to="/">
 						<Icon

--- a/src/components/organisms/Navbar/styles.module.scss
+++ b/src/components/organisms/Navbar/styles.module.scss
@@ -1,6 +1,13 @@
 @import '~theme/variables';
 
-nav {
+// scoped to a class (not the bare `nav` element selector, which CSS Modules
+// leave global) so these rules don't leak into other <nav> landmarks such as
+// the Lexicon sidebar
+.navbar {
+	// keep the site's monospace nav on every page — Lexicon's .theme wrapper
+	// otherwise swaps it to the system sans, which reflows the navbar so it no
+	// longer matches the rest of the site
+	font-family: $fontFamilyPrimary;
 	font-weight: $fontWeightHeavy;
 	align-items: baseline;
 	display: flex;
@@ -12,7 +19,7 @@ nav {
 	}
 }
 
-nav.white {
+.white {
 	color: $white !important;
 
 	a {

--- a/src/components/organisms/Navbar/styles.module.scss
+++ b/src/components/organisms/Navbar/styles.module.scss
@@ -16,6 +16,8 @@
 	position: relative;
 	a {
 		text-decoration: none;
+		// theme-ui's links.nav variant sets weight 400; bump links to semibold
+		font-weight: $fontWeightHeavy;
 	}
 }
 

--- a/src/components/organisms/Sidebar/index.js
+++ b/src/components/organisms/Sidebar/index.js
@@ -58,6 +58,8 @@ export default function SidebarWrapper({
 
 	return (
 		<Grid
+			as="nav"
+			aria-label={`${section || 'Section'} navigation`}
 			sx={{
 				gridTemplateColumns: '1fr',
 				gridTemplateRows: ['8rem', null, '12rem auto 8rem'],

--- a/src/components/templates/Lexicon/index.js
+++ b/src/components/templates/Lexicon/index.js
@@ -109,7 +109,7 @@ export default class Lexicon extends Component {
 									section="Lexicon"
 								/>
 
-								<div>
+								<main>
 									<ContainerMarkdown>
 										<Flex justify="space-between" align="baseline">
 											<h1>{mdx.frontmatter.title}</h1>
@@ -184,29 +184,46 @@ export default class Lexicon extends Component {
 										{/* <PreviousNext section='lexicon' current={post.id} /> */}
 									</ContainerMarkdown>
 									<Footer markdown light />
-								</div>
+								</main>
 
 								<Flex
 									align="center"
 									className={documentation.mobileMenuBar}
 									justify="space-between"
 								>
-									<Icon name="lexicon" color="white" height="2em" />
+									<Icon
+										name="lexicon"
+										color="white"
+										height="2em"
+										aria-hidden="true"
+									/>
 
-									{this.state.mobileSidebarVisible ? (
-										<Icon
-											name="close"
-											color="white"
-											onClick={this.toggleMobileSidebarVisibility}
-										/>
-									) : (
-										<Text
-											color="white"
-											onClick={this.toggleMobileSidebarVisibility}
-										>
-											Menu
-										</Text>
-									)}
+									<button
+										type="button"
+										onClick={this.toggleMobileSidebarVisibility}
+										aria-expanded={this.state.mobileSidebarVisible}
+										aria-label={
+											this.state.mobileSidebarVisible
+												? 'Close navigation menu'
+												: 'Open navigation menu'
+										}
+										sx={{
+											alignItems: 'center',
+											background: 'none',
+											border: 0,
+											color: 'white',
+											cursor: 'pointer',
+											display: 'flex',
+											font: 'inherit',
+											p: 0,
+										}}
+									>
+										{this.state.mobileSidebarVisible ? (
+											<Icon name="close" color="white" aria-hidden="true" />
+										) : (
+											<Text color="white">Menu</Text>
+										)}
+									</button>
 								</Flex>
 							</Grid>
 						)

--- a/src/components/templates/MainLayout/index.js
+++ b/src/components/templates/MainLayout/index.js
@@ -20,7 +20,7 @@ export default ({ children, section }) => (
 		<LogRocket />
 		<Navbar section={section} />
 
-		{children}
+		<main>{children}</main>
 
 		{/* <Container padding={{ p: '6rem 0 0' }}>
 			<Heading sx={{ textAlign: 'center', color: 'white' }} level={2}>

--- a/src/gatsby-plugin-theme-ui/components.js
+++ b/src/gatsby-plugin-theme-ui/components.js
@@ -202,7 +202,9 @@ export default {
 				transform: 'scaleX(0)',
 				width: 4,
 			},
-			'&:hover': {
+			// focus must match hover: theme-ui's NavLink default turns
+			// :focus the primary blue, which vanishes on the blue banner
+			'&:hover, &:focus, &:focus-visible': {
 				color: 'white',
 				transition: 'color 0.4s ease-out',
 				'&::after': {

--- a/src/markdown/lexicon/get-started.mdx
+++ b/src/markdown/lexicon/get-started.mdx
@@ -8,19 +8,19 @@ draft: false
 
 import { Grid, Box } from 'theme-ui'
 
-### Design language
+## Design language
 
 Lexicon is a design language that provides a common framework for building interfaces within the Liferay product ecosystem. It is a guide to foundations, components, patterns, and use cases that provide consistency and coherence to these products, and, ultimately, provides a satisfactory and unified experience to its users.
 
 Lexicon is a living project, evolving and adapting over time to new and rising technologies to meet the needs of the people.
 
-### Modular approach
+## Modular approach
 
 Lexicon takes a modular approach to interface design. It is a cohesive system that's able to respond to the various needs of Liferay's products through a base set of components. It seeks to simplify processes, reduce production times, and above all, to provide a consistent user experience across the board.
 
 To achieve this goal, Lexicon uses Brad Frost's Atomic Design approach to interface design: A work methodology, based on modularity, that seeks to give a more hierarchical and organized structure to the creation of interface design systems. It's a nonlinear process, organized across five stages: Atoms, Molecules, Organisms, Templates, and Pages.
 
-### Lexicon site
+## Lexicon site
 
 This site explains the design specs and proper usage of Lexicon's system of components for designers, developers, and overall digital creators. While it is primarily for the Liferay community, it is open to anyone who wants to use its components or make contributions or suggestions to improving it.
 
@@ -33,7 +33,7 @@ This site explains the design specs and proper usage of Lexicon's system of comp
 		/>
 	</Box>
 	<Box>
-		<h4>Foundations</h4>
+		<h3>Foundations</h3>
 		<p>
 			These are the principles that the design system is built on. Modifications to
 			these principles affect the component's behavior. These include foundational
@@ -48,7 +48,7 @@ This site explains the design specs and proper usage of Lexicon's system of comp
 		/>
 	</Box>
 	<Box>
-		<h4>Components</h4>
+		<h3>Components</h3>
 		<p>
 			This section contains the common components that are essential to build
 			interfaces. Each component defines its rules and behaviors. Each component's
@@ -65,7 +65,7 @@ This site explains the design specs and proper usage of Lexicon's system of comp
 		/>
 	</Box>
 	<Box>
-		<h4>Templates</h4>
+		<h3>Templates</h3>
 		<p>
 			Templates offer prebuilt solutions to tackle repetitive interface challenges.
 			They speed up the design process, as they only require minor modifications to
@@ -80,7 +80,7 @@ This site explains the design specs and proper usage of Lexicon's system of comp
 		/>
 	</Box>
 	<Box>
-		<h4>Satellites</h4>
+		<h3>Satellites</h3>
 		<p>
 			These components are for the needs of specific products or applications. They
 			are built using Lexicon's foundations, patterns and components. They belong to the
@@ -96,7 +96,7 @@ This site explains the design specs and proper usage of Lexicon's system of comp
 		/>
 	</Box>
 	<Box>
-		<h4>Examples</h4>
+		<h3>Examples</h3>
 		<p>
 			This section showcases practical designs by UX Designers that demonstrate how components and satellites are applied to create Lexicon
 			interfaces that tackle specific scenarios.
@@ -111,6 +111,6 @@ This site explains the design specs and proper usage of Lexicon's system of comp
 </Grid>
 
 
-### Implement Lexicon
+## Implement Lexicon
 
 Lexicon is not an implementation. It is a set of patterns, rules, and behaviors that any library can implement. Liferay's Lexicon Experience Language web implementation is [Clay](https://clayui.com/).

--- a/src/markdown/lexicon/resources.mdx
+++ b/src/markdown/lexicon/resources.mdx
@@ -8,7 +8,7 @@ draft: false
 import { Button, Grid, Box, Embed } from 'theme-ui'
 import { Link } from 'components/atoms'
 
-### Design Libraries
+## Design Libraries
 
 Creating your own interfaces using Lexicon is pretty easy using our Figma or Sketch libraries. Our libraries provide you with our foundations and components that you can use to build your interfaces.
 
@@ -40,13 +40,13 @@ Creating your own interfaces using Lexicon is pretty easy using our Figma or Ske
 	</Box>
 </Grid>
 
-### Blog posts
+## Blog posts
 
 [Building charts for multiple products](https://medium.com/liferaydesign/building-charts-for-multiple-products-bb399ef1a71e) _by Emiliano Cicero_, September 2018
 
 [Designing animations for a multicultural product](https://medium.com/liferaydesign/designing-for-a-multicultural-product-9564bc657cb5) _by Susana Vazquez_, July 2018
 
-### Presentations
+## Presentations
 
 **2019 February**
 
@@ -77,6 +77,6 @@ Principles, grid, distances... are important elements to know how to craft infer
 
 <Embed variant='embed.slides' src="//speakerdeck.com/player/2e287bdf09a44bb78231e707a84a26a5" />
 
-### Previous Lexicon Versions
+## Previous Lexicon Versions
 
 [Lexicon Version 1.0](../../lexicon-1)

--- a/src/pages/lexicon.js
+++ b/src/pages/lexicon.js
@@ -13,6 +13,7 @@ const Lexicon = () => (
 			description="Lexicon is a design language that provides a common framework for building interfaces within the Liferay product ecosystem."
 			pageTitle="Liferay Lexicon | An Experience Language for Crafting Beautiful UI"
 		/>
+		<main>
 		<Banner
 			headline="Lexicon"
 			subtitle="An Experience Language for Crafting Beautiful UI"
@@ -31,7 +32,6 @@ const Lexicon = () => (
 					}}
 				>
 					<Text
-						color="#c4cacb"
 						weight="700"
 						size="12px"
 						type="p"
@@ -90,20 +90,31 @@ const Lexicon = () => (
 						<Link
 							className={documentation.social}
 							to="https://github.com/liferay-design"
+							aria-label="Liferay Design on GitHub"
 						>
-							<Icon sx={{ fill: 'white' }} name="github" />
+							<Icon sx={{ fill: 'white' }} name="github" aria-hidden="true" />
 						</Link>
 						<Link
 							className={documentation.social}
 							to="https://dribbble.com/liferay"
+							aria-label="Liferay on Dribbble"
 						>
-							<Icon sx={{ fill: 'white' }} name="dribbble" />
+							<Icon
+								sx={{ fill: 'white' }}
+								name="dribbble"
+								aria-hidden="true"
+							/>
 						</Link>
 						<Link
 							className={documentation.social}
 							to="https://twitter.com/Liferay_Lexicon"
+							aria-label="Liferay Lexicon on Twitter"
 						>
-							<Icon sx={{ fill: 'white' }} name="twitter" />
+							<Icon
+								sx={{ fill: 'white' }}
+								name="twitter"
+								aria-hidden="true"
+							/>
 						</Link>
 					</Box>
 				</Grid>
@@ -136,6 +147,7 @@ const Lexicon = () => (
 				/>
 			</Container>
 		</section>
+		</main>
 		<Footer background="#30313f" />
 	</div>
 )

--- a/src/theme/global.scss
+++ b/src/theme/global.scss
@@ -14,13 +14,16 @@ body {
 	font-size: 16px;
 	font-family: $fontFamilyPrimary;
 	margin: 0;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	text-rendering: optimizeLegibility;
 	// overflow-x: hidden; // fixing #660
 	::selection {
-		background: #05f;
+		background: $primary;
 		color: #fff;
 	}
 	::-moz-selection {
-		background: #05f;
+		background: $primary;
 		color: #fff;
 	}
 }
@@ -39,12 +42,54 @@ p {
 	}
 }
 
+h1,
+h2,
+h3 {
+	text-wrap: balance;
+}
+
 h1 {
 	line-height: 1.2;
 }
 
 a {
 	text-decoration: none;
+	transition: color 0.15s ease, opacity 0.15s ease;
+}
+
+// visible, on-brand keyboard focus without bothering mouse users
+:focus-visible {
+	outline: 2px solid $primary;
+	outline-offset: 2px;
+	border-radius: 2px;
+}
+
+// slim, rounded scrollbars site-wide
+* {
+	scrollbar-width: thin;
+	scrollbar-color: $main-l5 transparent;
+}
+
+::-webkit-scrollbar {
+	height: 8px;
+	width: 8px;
+}
+
+::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+	background-color: $main-l5;
+	border-radius: 8px;
+
+	&:hover {
+		background-color: $main-l4;
+	}
+}
+
+::-webkit-scrollbar-corner {
+	background: transparent;
 }
 
 img {

--- a/src/theme/lexicon.module.scss
+++ b/src/theme/lexicon.module.scss
@@ -31,7 +31,7 @@
 	// lexicon homepage
 	.vertical {
 		@include small-caps;
-		color: $main-l4;
+		color: $main-l3;
 		font-size: 13px;
 		left: -4rem;
 		position: absolute;
@@ -117,8 +117,10 @@
 			line-height: 1.75;
 			margin-bottom: $base-size * 0.7;
 
+			// underline so body links aren't distinguished by colour alone
 			a {
 				color: $brand-primary;
+				text-decoration: underline;
 			}
 		}
 
@@ -242,6 +244,7 @@
 
 		li > a {
 			color: $brand-primary;
+			text-decoration: underline;
 		}
 	}
 }

--- a/src/utils/logRocket.js
+++ b/src/utils/logRocket.js
@@ -1,21 +1,19 @@
-import React, { Component } from 'react'
-import { Helmet } from 'react-helmet'
+import { Component } from 'react'
+import LogRocketLib from 'logrocket'
+
+const APP_ID = 'vvepjf/liferaydesign'
 
 export class LogRocket extends Component {
 	componentDidMount() {
-		window.LogRocket && window.LogRocket.init('vvepjf/liferaydesign')
+		// Load from the bundled npm package (version-locked via package-lock)
+		// instead of the rolling CDN URL. The CDN file is unversioned, so the
+		// pinned SRI hash broke whenever LogRocket shipped a new build and the
+		// browser blocked LogRocket.min.js outright.
+		LogRocketLib.init(APP_ID)
 	}
 
 	render() {
-		return (
-			<Helmet>
-				<script
-					src="https://cdn.lr-ingest.io/LogRocket.min.js"
-					integrity="sha384-b0XbgzE6J/qtc+4HLtAb/hJlDBpi4wFgJu6KmnqBMSxJQG0VrkHjKb+DDaxpAjdN"
-					crossorigin="anonymous"
-				/>
-			</Helmet>
-		)
+		return null
 	}
 }
 


### PR DESCRIPTION
A pass of visual polish and accessibility fixes across the site, structured as one commit per concern.

## Commits

1. **Animate the hero headline and the footer mural** — staggered line-reveal on *"We are Liferayʼs / global team of / designers."* with a brand-blue underline; the geometric footer mural now moves continuously and subtly. Tone-on-tone hero accent tuned to WCAG AA (3:1) for large text. All motion behind `prefers-reduced-motion`.
2. **Keep the navbar header consistent across all sections** — Lexicon's `.theme` font no longer leaks into the navbar (it stays the site monospace); navbar styles scoped to a `.navbar` class so they stop bleeding into other `<nav>` landmarks.
3. **Hide Handbook from the primary navigation** — it's outdated and renders poorly; still reachable via its existing changelog entry until refreshed.
4. **Accessibility pass** — `<main>` landmarks + Lexicon sidebar as `<nav>`; keyboard focus that's actually visible (nav links, cards, a real `<button>` for the mobile menu); `aria-label`s on icon-only links and search; decorative icons `aria-hidden`; Accordion `<ul>`→`<div>`; heading order h1→h2→h3; Heading atom no longer leaks an invalid `textAlign` DOM attribute.
5. **Fix text contrast to meet WCAG AA** — card/search secondary text, the dark Clay-card CTA, the vertical "Explore Lexicon" label, the dark footer credits, and underlined body links in docs.
6. **Global UI polish** — slim rounded scrollbars, visible `:focus-visible` ring, brand-blue selection, font smoothing, balanced heading wrapping.
7. **Load LogRocket from the npm package instead of the CDN** — the pinned SRI hash on the unversioned CDN file kept breaking and blocking the script; the npm package is version-locked and removes the external dependency.

## Verified
- `gatsby develop` compiles clean; home, Lexicon landing and docs, team/alumni all render.
- Accessibility audit items on `/lexicon` and `/lexicon/get-started` resolved (landmarks, contrast, headings, names, keyboard).

## Notes
- Dark mode was explored and set aside on the `Dark` branch; none of it is in this PR.
- Moving Alex Clementi to Alumni is a separate content PR (#1326).