### PR TITLE
Move Alex Clementi to Alumni

### DIFF
--- a/src/markdown/Authors.yaml
+++ b/src/markdown/Authors.yaml
@@ -17,10 +17,11 @@
   alumni: true
 - id: Alex Clementi
   title: Product Designer
-  active: true
+  active: false
   icon: fa_binoculars
   startDate: 2022-11-07
   office: Concorezzo
+  alumni: true
 - id: Andrea Censi
   title: Staff Product Designer
   active: true


### PR DESCRIPTION
Sets `active: false` and `alumni: true` for Alex Clementi in `Authors.yaml`, moving the profile from the active Team page to Alumni. Content-only change.